### PR TITLE
Replace log4j by loglevel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1610,15 +1610,11 @@
                 "whatwg-url": "^8.0.0"
             }
         },
-        "date-format": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
-            "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w=="
-        },
         "debug": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -1896,11 +1892,6 @@
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
             }
-        },
-        "flatted": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-            "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
         },
         "form-data": {
             "version": "3.0.1",
@@ -4017,17 +4008,10 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "log4js": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
-            "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
-            "requires": {
-                "date-format": "^3.0.0",
-                "debug": "^4.1.1",
-                "flatted": "^2.0.1",
-                "rfdc": "^1.1.4",
-                "streamroller": "^2.2.4"
-            }
+        "loglevel": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+            "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
         },
         "lru-cache": {
             "version": "6.0.0",
@@ -4123,7 +4107,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -4369,11 +4354,6 @@
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true
         },
-        "rfdc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
-        },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4479,46 +4459,6 @@
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
                     "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
                     "dev": true
-                }
-            }
-        },
-        "streamroller": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
-            "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
-            "requires": {
-                "date-format": "^2.1.0",
-                "debug": "^4.1.1",
-                "fs-extra": "^8.1.0"
-            },
-            "dependencies": {
-                "date-format": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-                    "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "universalify": {
-                    "version": "0.1.2",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "fast-xml-parser": "^3.17.4",
         "fs-extra": "^9.0.1",
         "lodash": "^4.17.21",
-        "log4js": "^6.3.0",
+        "loglevel": "^1.7.1",
         "walkdir": "^0.4.1",
         "which": "^2.0.2"
     },

--- a/src/AssetsJson/Extractor.ts
+++ b/src/AssetsJson/Extractor.ts
@@ -1,10 +1,9 @@
+import log from 'loglevel';
+import { CaseInsensitiveMap, DependencyDetails, Extractor } from '../../model';
 import { CommonUtils } from '../CommonUtils';
-import { DependencyDetails, Extractor, CaseInsensitiveMap } from '../../model';
 import { AssetsUtils } from './Utils';
-import * as log from 'log4js';
 
 export const assetsFileName: string = 'project.assets.json';
-const logger = log.getLogger();
 
 export class AssetsExtractor implements Extractor {
     constructor(private _assets: any) {}
@@ -17,7 +16,7 @@ export class AssetsExtractor implements Extractor {
      */
     public static isCompatible(projectName: string, dependenciesSource: string): boolean {
         if (dependenciesSource.endsWith(assetsFileName)) {
-            logger.debug('Found', dependenciesSource, 'file for project:', projectName);
+            log.debug('Found', dependenciesSource, 'file for project:', projectName);
             return true;
         }
         return false;

--- a/src/AssetsJson/Utils.ts
+++ b/src/AssetsJson/Utils.ts
@@ -1,13 +1,11 @@
-import { absentNupkgWarnMsg } from '../DependencyTree/Utils';
-import * as pathUtils from 'path';
 import * as fse from 'fs-extra';
-import * as log from 'log4js';
+import log from 'loglevel';
+import * as pathUtils from 'path';
+import { CaseInsensitiveMap, DependencyDetails } from '../../model';
 import { CommonUtils } from '../CommonUtils';
-import { assetsFileName } from './Extractor';
-import { DependencyDetails, CaseInsensitiveMap } from '../../model';
+import { absentNupkgWarnMsg } from '../DependencyTree/Utils';
 import { Dependency } from '../Structure/Dependency';
-
-const logger = log.getLogger();
+import { assetsFileName } from './Extractor';
 
 export class AssetsUtils {
     /**
@@ -55,7 +53,7 @@ export class AssetsUtils {
             // A package is a dependency if a nuget package file exists in Nuget cache directory.
             if (!fse.pathExistsSync(nupkgFilePath)) {
                 if (this.isPackagePartOfTargetDependencies(assets, libraryPath)) {
-                    logger.warn(
+                    log.warn(
                         'The file',
                         nupkgFilePath,
                         "doesn't exist in the NuGet cache directory but it does exist as a target in the assets files." +

--- a/src/DependencyTree/Tree.ts
+++ b/src/DependencyTree/Tree.ts
@@ -1,7 +1,5 @@
-import * as log from 'log4js';
-import { DependencyDetails, CaseInsensitiveMap } from '../../model';
-
-const logger = log.getLogger();
+import log from 'loglevel';
+import { CaseInsensitiveMap, DependencyDetails } from '../../model';
 
 export class DependencyTree {
     private _dependencies: DependencyTree[] = [];
@@ -71,7 +69,7 @@ export class DependencyTree {
                 );
                 this._dependencies?.push(childTree);
             } else {
-                logger.warn('unexpected dependency found in children array: %s', childId);
+                log.warn('unexpected dependency found in children array: %s', childId);
             }
         }
     }

--- a/src/DependencyTree/Utils.ts
+++ b/src/DependencyTree/Utils.ts
@@ -1,8 +1,6 @@
-import { DependencyDetails, Extractor, CaseInsensitiveMap } from '../../model';
+import log from 'loglevel';
+import { CaseInsensitiveMap, DependencyDetails, Extractor } from '../../model';
 import { DependencyTree } from './Tree';
-import * as log from 'log4js';
-
-const logger = log.getLogger();
 
 type Root = DependencyTree[];
 export const absentNupkgWarnMsg: string =
@@ -26,7 +24,7 @@ export class DependenciesUtils {
             if (dependency) {
                 rootTree.push(new DependencyTree(dependency._id, dependency._version, allDependencies, childrenMap));
             } else {
-                logger.warn('unexpected dependency found in root dependencies array: %s', rootId);
+                log.warn('unexpected dependency found in root dependencies array: %s', rootId);
             }
         }
         return rootTree;

--- a/src/PackagesConfig/Extractor.ts
+++ b/src/PackagesConfig/Extractor.ts
@@ -1,16 +1,14 @@
-import { CommonUtils } from '../CommonUtils';
-import { NugetPackage } from './NugetPackage';
-import { DependencyDetails, Extractor, CaseInsensitiveMap } from '../../model';
 import * as exec from 'child_process';
 import * as fse from 'fs-extra';
+import log from 'loglevel';
 import * as pathUtils from 'path';
+import { CaseInsensitiveMap, DependencyDetails, Extractor } from '../../model';
+import { CommonUtils } from '../CommonUtils';
 import { absentNupkgWarnMsg } from '../DependencyTree/Utils';
-import * as log from 'log4js';
 import { Dependency } from '../Structure/Dependency';
+import { NugetPackage } from './NugetPackage';
 
 const packagesFileName: string = 'packages.config';
-const logger = log.getLogger();
-
 export class PackagesExtractor implements Extractor {
     constructor(
         private _allDependencies: CaseInsensitiveMap<DependencyDetails>,
@@ -49,7 +47,7 @@ export class PackagesExtractor implements Extractor {
      */
     public static isCompatible(projectName: string, dependenciesSource: string): boolean {
         if (dependenciesSource.endsWith(packagesFileName)) {
-            logger.debug('Found', dependenciesSource, 'file for project:', projectName);
+            log.debug('Found', dependenciesSource, 'file for project:', projectName);
             return true;
         }
         return false;
@@ -194,7 +192,7 @@ export class PackagesExtractor implements Extractor {
                 this._allDependencies.set(id, new Dependency(id, version));
                 this._childrenMap.set(id, Array.from(pack.dependencies.keys()));
             } else {
-                logger.warn(
+                log.warn(
                     'The following NuGet package %s with version %s was not found in the NuGet cache %s.' +
                         absentNupkgWarnMsg,
                     nuget.id,

--- a/src/PackagesConfig/NugetPackage.ts
+++ b/src/PackagesConfig/NugetPackage.ts
@@ -1,9 +1,7 @@
-import { CommonUtils } from '../CommonUtils';
 import * as lodash from 'lodash';
-import * as log from 'log4js';
+import log from 'loglevel';
 import { CaseInsensitiveMap } from '../../model';
-
-const logger = log.getLogger();
+import { CommonUtils } from '../CommonUtils';
 
 export class NugetPackage {
     private _dependencies: CaseInsensitiveMap<boolean> = new CaseInsensitiveMap<boolean>();
@@ -41,7 +39,7 @@ export class NugetPackage {
         try {
             nuspec = CommonUtils.parseXmlToObject(nuspecContent);
         } catch (error) {
-            logger.warn(
+            log.warn(
                 "Package: %s couldn't be parsed due to: %s. Skipping the package dependency.",
                 this._id + ':' + this._version,
                 error

--- a/src/Structure/Project.ts
+++ b/src/Structure/Project.ts
@@ -1,11 +1,9 @@
+import log from 'loglevel';
 import { Extractor } from '../../model';
+import { AssetsExtractor } from '../AssetsJson/Extractor';
 import { DependencyTree } from '../DependencyTree/Tree';
 import { DependenciesUtils } from '../DependencyTree/Utils';
-import * as log from 'log4js';
 import { PackagesExtractor } from '../PackagesConfig/Extractor';
-import { AssetsExtractor } from '../AssetsJson/Extractor';
-
-const logger = log.getLogger();
 
 export class ProjectBuilder {
     constructor(
@@ -79,7 +77,7 @@ export class ProjectBuilder {
         if (AssetsExtractor.isCompatible(projectName, dependenciesSource)) {
             return AssetsExtractor.newExtractor(dependenciesSource);
         }
-        logger.debug('Unsupported project dependencies for project: %s', projectName);
+        log.debug('Unsupported project dependencies for project: %s', projectName);
         return null as any;
     }
 }

--- a/src/Structure/Solution.ts
+++ b/src/Structure/Solution.ts
@@ -1,13 +1,12 @@
-import { ProjectBuilder } from './Project';
-import { CommonUtils } from '../CommonUtils';
-import * as pathUtils from 'path';
 import * as fs from 'fs';
-import * as log from 'log4js';
+import log from 'loglevel';
+import * as pathUtils from 'path';
 import * as walkdir from 'walkdir';
+import { CommonUtils } from '../CommonUtils';
+import { ProjectBuilder } from './Project';
 
 const packagesFileName: string = 'packages.config';
 const assetsFileName: string = 'project.assets.json';
-const logger = log.getLogger();
 
 export class Solution {
     constructor(
@@ -63,7 +62,7 @@ export class Solution {
         walkdir.find(pathUtils.parse(slnFilePath).dir, { follow_symlinks: true, sync: true }, (path: string) => {
             if (path.endsWith(packagesFileName) || path.endsWith(assetsFileName)) {
                 curDependenciesSources.push(pathUtils.resolve(path));
-                logger.debug('found: ', path);
+                log.debug('found: ', path);
             }
         });
         // Sort by length ascending.
@@ -91,7 +90,7 @@ export class Solution {
             try {
                 const parsed: ParsedProject = this.parseProject(project, pathUtils.parse(this._filePath).dir);
                 if (!parsed.csprojPath.endsWith('.csproj')) {
-                    logger.debug(
+                    log.debug(
                         'Skipping a project "%s", since it doesn\'t have a csproj file path.',
                         parsed.projectName
                     );
@@ -99,7 +98,7 @@ export class Solution {
                 }
                 this.loadProject(parsed.projectName, parsed.csprojPath);
             } catch (error) {
-                logger.error(
+                log.error(
                     "Failed parsing and loading project '%s' from solution %s': %s",
                     project,
                     this._filePath,
@@ -119,7 +118,7 @@ export class Solution {
             this.loadProject(projectName, csprojFiles[0]);
             return;
         }
-        logger.warn('Expected only one undeclared project in solution dir. Found: %d', csprojFiles.length);
+        log.warn('Expected only one undeclared project in solution dir. Found: %d', csprojFiles.length);
     }
 
     /**
@@ -144,7 +143,7 @@ export class Solution {
 
         // If no dependencies source was found, we will skip the current project.
         if (!dependenciesSource) {
-            logger.debug('Project dependencies was not found for project: %s', projectName);
+            log.debug('Project dependencies was not found for project: %s', projectName);
         }
 
         // Create a project builder with an extractor. If successful, add to projects list.

--- a/test/Main.spec.ts
+++ b/test/Main.spec.ts
@@ -1,8 +1,6 @@
-import * as log from 'log4js';
-import { NugetDepsTree } from '../src';
+import log from 'loglevel';
 import * as pathUtils from 'path';
-
-const logger = log.getLogger();
+import { NugetDepsTree } from '../src';
 
 describe('Nuget Deps Tree Tests', () => {
     test('Run', () => {
@@ -10,6 +8,6 @@ describe('Nuget Deps Tree Tests', () => {
             pathUtils.join(__dirname, 'resources', 'packagereferences', 'simple-multi-assets', 'assets.sln')
         );
         expect(tree.projects).toHaveLength(2);
-        logger.info(tree);
+        log.info(tree);
     });
 });


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/nuget-deps-tree#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

There is an issue with log4js when using Webpack:
> WARNING in ./node_modules/log4js/lib/appenders/index.js 26:11-30
Critical dependency: the request of a dependency is an expression
 @ ./node_modules/log4js/lib/log4js.js 27:18-40
 @ ./node_modules/nuget-deps-tree/dist/src/Structure/Solution.js 27:25-42
 @ ./node_modules/nuget-deps-tree/dist/src/Main.js 4:19-50
 @ ./node_modules/nuget-deps-tree/dist/src/index.js 3:13-30
 @ ./node_modules/nuget-deps-tree/dist/index.js 14:13-29
 @ ./src/main/utils/nugetUtils.ts 26:26-52
 @ ./src/main/treeDataProviders/dependenciesTree/dependenciesTreeFactory.ts 8:21-54
 @ ./src/main/treeDataProviders/dependenciesTree/dependenciesDataProvider.ts 36:34-70
 @ ./src/main/treeDataProviders/treesManager.ts 26:35-89
 @ ./src/extension.ts 33:23-71

Let's replace it with the more popular [loglevel](https://www.npmjs.com/package/loglevel) module.