### PR TITLE
Export types

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -7,7 +7,7 @@ export class NugetDepsTree {
      * @param slnFilePath
      * @returns object representation of the dependencies tree.
      */
-    public static generate(slnFilePath: string): any {
+    public static generate(slnFilePath: string): Tree {
         const sol: Solution = Solution.create(slnFilePath);
 
         const nugetDepsTree = new Tree([]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export { NugetDepsTree } from './Main';
+export { Tree, Project } from './Structure/OutputStructure';
+export { DependencyTree } from './DependencyTree/Tree';


### PR DESCRIPTION
Fixes #24

- [x] All [tests](https://github.com/jfrog/nuget-deps-tree#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `npm run format` for formatting the code before submitting the pull request.
-----

With this change i can now reference the types (classes) in my consuming typescript project, for example:

```ts
import { Tree as NugetPackageTree } from 'nuget-deps-tree';
```