### PR TITLE
Packages may not be array

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,17 @@
             "internalConsoleOptions": "neverOpen",
             "disableOptimisticBPs": true,
             "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Run nuget-deps-tree on C-Sharp solution",
+            "program": "${workspaceFolder}/bin/command.ts",
+            "args": ["/path/to/your.sln"],
+            "cwd": "${workspaceFolder}",
+            "env": {},
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "openOnSessionStart"
         }
     ]
 }

--- a/src/PackagesConfig/Extractor.ts
+++ b/src/PackagesConfig/Extractor.ts
@@ -169,7 +169,13 @@ export class PackagesExtractor implements Extractor {
      * @param globalPackagesCache
      */
     public extract(packagesConfig: any, globalPackagesCache: string) {
-        const packages: any = CommonUtils.getPropertyOrUndefined(packagesConfig, 'packages.package');
+        let packages: any = CommonUtils.getPropertyOrUndefined(packagesConfig, 'packages.package');
+        if (!packages) {
+            return;
+        }
+        if (!Array.isArray(packages)) {
+            packages = [packages];
+        }
         for (const nuget of packages) {
             const id: string = nuget.id;
             const version: string = nuget.version;


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/nuget-deps-tree#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

In some projects, the `packages.package` was returned not as an array.
causing `TypeError` that resulted in an ignored project when extracting.