### PR TITLE
Fix matching a project source where multiple exist

### DIFF
--- a/src/Structure/Solution.ts
+++ b/src/Structure/Solution.ts
@@ -132,10 +132,13 @@ export class Solution {
         // a directory with the project name under the solution root.
         const projectRootPath: string = pathUtils.dirname(csprojPath);
         const projectPathPattern: string = projectRootPath + pathUtils.sep;
-        const projectNamePattern: string = pathUtils.sep + projectName + pathUtils.sep;
+        const projectNamePattern: string = pathUtils.sep + projectName;
         let dependenciesSource: string = '';
         this._dependenciesSources.some((source: string) => {
-            if (source.includes(projectPathPattern) || source.includes(projectNamePattern)) {
+            const isInRoot: boolean = projectRootPath === pathUtils.dirname(source);
+            const isUnderProjectDir: boolean = source.includes(projectPathPattern);
+            const isUnderSubDirWithProjectName: boolean = source.endsWith(projectNamePattern);
+            if (isInRoot || isUnderProjectDir || isUnderSubDirWithProjectName) {
                 dependenciesSource = source;
                 return true;
             }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/nuget-deps-tree#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----
In nuget project where there is a sub directory in the same name of the root project and another sub directory with `/obj/` dir, it will not set the right source file for the project