### PR TITLE
Fix package.metadata.dependencies.group type error

### DIFF
--- a/src/PackagesConfig/NugetPackage.ts
+++ b/src/PackagesConfig/NugetPackage.ts
@@ -64,7 +64,7 @@ export class NugetPackage {
         if (groupArray) {
             for (const group of groupArray) {
                 if (group.dependency) {
-                    for (const dependency of group.dependency) {
+                    for (const dependency of Array.isArray(group.dependency) ? group.dependency : [group.dependency]) {
                         this._dependencies?.set(dependency.id, true);
                     }
                 }

--- a/src/PackagesConfig/NugetPackage.ts
+++ b/src/PackagesConfig/NugetPackage.ts
@@ -54,7 +54,7 @@ export class NugetPackage {
         }
         const depArray: any = lodash.get(metaDataDep, 'dependency');
         if (depArray) {
-            for (const dependency of depArray) {
+            for (const dependency of Array.isArray(depArray) ? depArray : [depArray]) {
                 this._dependencies?.set(dependency.id, true);
             }
         }
@@ -62,7 +62,7 @@ export class NugetPackage {
         // Dependencies might be grouped.
         const groupArray: any = lodash.get(metaDataDep, 'group');
         if (groupArray) {
-            for (const group of groupArray) {
+            for (const group of Array.isArray(groupArray) ? groupArray : [groupArray]) {
                 if (group.dependency) {
                     for (const dependency of Array.isArray(group.dependency) ? group.dependency : [group.dependency]) {
                         this._dependencies?.set(dependency.id, true);

--- a/test/PackagesConfig.spec.ts
+++ b/test/PackagesConfig.spec.ts
@@ -1,8 +1,67 @@
 import * as path from 'path';
 import { PackagesExtractor } from '../src/PackagesConfig/Extractor';
 import { DependencyDetails, CaseInsensitiveMap } from '../model';
+import { NugetPackage } from '../src/PackagesConfig/NugetPackage';
 
 describe('Packages Config Tests', () => {
+    test('NugetPackage group.dependency handles array and single object', () => {
+        // Single dependency object
+        const nuspecSingle: string = `<?xml version="1.0"?>
+        <package>
+          <metadata>
+            <id>testpkg</id>
+            <version>1.0.0</version>
+            <dependencies>
+              <group>
+                <dependency id="dep1" />
+              </group>
+            </dependencies>
+          </metadata>
+        </package>`;
+        const pkgSingle: NugetPackage = new NugetPackage('testpkg', '1.0.0', nuspecSingle);
+        expect(pkgSingle.dependencies.has('dep1')).toBe(true);
+
+        // Multiple dependencies array
+        const nuspecArray: string = `<?xml version="1.0"?>
+        <package>
+          <metadata>
+            <id>testpkg</id>
+            <version>1.0.0</version>
+            <dependencies>
+              <group>
+                <dependency id="dep1" />
+                <dependency id="dep2" />
+              </group>
+            </dependencies>
+          </metadata>
+        </package>`;
+        const pkgArray: NugetPackage = new NugetPackage('testpkg', '1.0.0', nuspecArray);
+        expect(pkgArray.dependencies.has('dep1')).toBe(true);
+        expect(pkgArray.dependencies.has('dep2')).toBe(true);
+
+        // Multiple groups with mixed one/multiple dependencies
+        const nuspecMixed: string = `<?xml version="1.0"?>
+        <package>
+          <metadata>
+            <id>testpkg</id>
+            <version>1.0.0</version>
+            <dependencies>
+              <group>
+                <dependency id="dep1" />
+              </group>
+              <group>
+                <dependency id="dep2" />
+                <dependency id="dep3" />
+              </group>
+            </dependencies>
+          </metadata>
+        </package>`;
+        const pkgMixed: NugetPackage = new NugetPackage('testpkg', '1.0.0', nuspecMixed);
+        expect(pkgMixed.dependencies.has('dep1')).toBe(true);
+        expect(pkgMixed.dependencies.has('dep2')).toBe(true);
+        expect(pkgMixed.dependencies.has('dep3')).toBe(true);
+    });
+
     const resources: string = path.join(__dirname, 'resources');
     const packagesCache: string = path.join(resources, 'packagesconfig', 'packages');
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/nuget-deps-tree#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `npm run format` for formatting the code before submitting the pull request.
-----

Fix:

```
Failed parsing and loading project 'Project("{FAE....': TypeError: group.dependency is not iterable
```

